### PR TITLE
Speed up slider switch layout by using native extractAlpha() method

### DIFF
--- a/android-switch-demo/src/com/appscumen/example/MySwitch.java
+++ b/android-switch-demo/src/com/appscumen/example/MySwitch.java
@@ -972,13 +972,7 @@ public class MySwitch extends CompoundButton {
             //Log.d(TAG,"mask width="+maskBitmap.getWidth()+" mask.height="+maskBitmap.getHeight());
             //Log.d(TAG,"mask 0,0="+String.format("%x", (maskBitmap.getPixel(0,0)))+" mask 40,40="+String.format("%x", (maskBitmap.getPixel(40,40))));
         
-            maskBitmap = Bitmap.createBitmap(mSwitchRight - mSwitchLeft, mSwitchBottom - mSwitchTop,  Config.ARGB_8888);
-            int width = tempBitmap.getWidth(),  height = tempBitmap.getHeight();
-            for (int x=0; x<width; x++) {
-                for (int y=0; y<height; y++) {
-        	        maskBitmap.setPixel(x, y, (tempBitmap.getPixel(x,y) & 0xFF000000));
-                }
-            }
+            maskBitmap = tempBitmap.extractAlpha();
         
             //Log.d(TAG,"mask 0,0="+String.format("%x", (maskBitmap.getPixel(0,0)))+" mask 40,40="+String.format("%x", (maskBitmap.getPixel(40,40))));
 


### PR DESCRIPTION
Was making use of this great widget, but having performance problems on layout.  I found that most of the time was being spent in onLayout() iterating over the background mask to extract the alpha layer to a separate mask drawable.  Replacing that loop with a call to Bitmap.extractAlpha() eliminated the performance issues I was having.

Sample layout times measured on my Nexus One:
Before: 1.6 Seconds
After : 7 milliseconds
